### PR TITLE
refactor: move trash handling down to session

### DIFF
--- a/AgentKit/Agent.swift
+++ b/AgentKit/Agent.swift
@@ -107,8 +107,6 @@ public class Agent {
                     try await .item(item(request))
                 case .list(let request):
                     try await .list(list(request))
-                case .exists(let request):
-                    try await .exists(exists(request))
                 case .setAttributes(let request):
                     try await .setAttributes(setAttributes(request))
                 case .createSymlink(let request):
@@ -173,8 +171,7 @@ public class Agent {
         let session = try await sessions.connect(id: request.domainId)
         let childId = try await session.child(
             of: NSFileProviderItemIdentifier(request.parentId),
-            path: request.path,
-            ifNotExists: request.ifNotExists
+            path: request.path
         )
         return ChildResponse(itemId: childId.rawValue)
     }
@@ -230,16 +227,6 @@ public class Agent {
         return ListResponse(fileInfos: entries)
     }
 
-    func exists(
-        _ request: ExistsRequest
-    ) async throws -> ExistsResponse {
-        let session = try await sessions.connect(id: request.domainId)
-        let exists = await session.exists(
-            for: NSFileProviderItemIdentifier(request.itemId)
-        )
-        return ExistsResponse(exists: exists)
-    }
-
     func setAttributes(
         _ request: SetAttributesRequest
     ) async throws -> SetAttributesResponse {
@@ -285,8 +272,7 @@ public class Agent {
         try await session.move(
             NSFileProviderItemIdentifier(request.itemId),
             toParent: NSFileProviderItemIdentifier(request.newParentId),
-            name: request.newName,
-            ifParentNotExists: request.ifParentNotExists
+            name: request.newName
         )
         return MoveResponse()
     }

--- a/AgentKit/DomainDB.swift
+++ b/AgentKit/DomainDB.swift
@@ -5,20 +5,25 @@ import SwiftData
 
 private let logger = Logger(category: "DomainDB")
 
+enum OnNotExists: Codable, PrettyDescribable {
+    case fail
+    case create
+}
+
 @ModelActor
-public actor DomainDB {
+actor DomainDB {
     private static func url(for id: UUID) -> URL {
         SSHadow.groupUrl.appendingPathComponent(
             "DomainDB-\(id.uuidString).store"
         )
     }
 
-    public static func model(for id: UUID) -> ModelConfiguration {
+    static func model(for id: UUID) -> ModelConfiguration {
         ModelConfiguration(url: url(for: id))
     }
 
     @discardableResult
-    public static func open(
+    static func open(
         config: ModelConfiguration
     ) async throws -> DomainDB {
         let schema = Schema([ItemModel.self])
@@ -67,7 +72,7 @@ public actor DomainDB {
         )
     }
 
-    public static func delete(id: UUID) async throws {
+    static func delete(id: UUID) async throws {
         let basePath = url(for: id).path
 
         for suffix in ["", "-shm", "-wal"] {
@@ -78,7 +83,7 @@ public actor DomainDB {
         }
     }
 
-    public func fetch(id: NSFileProviderItemIdentifier) -> ItemModel? {
+    func fetch(id: NSFileProviderItemIdentifier) -> ItemModel? {
         let rawId = id.rawValue
         let descriptor = FetchDescriptor<ItemModel>(
             predicate: #Predicate { row in
@@ -88,7 +93,7 @@ public actor DomainDB {
         return try? modelContext.fetch(descriptor).first
     }
 
-    public func fetch(
+    func fetch(
         parentId: NSFileProviderItemIdentifier,
         name: String
     ) -> ItemModel? {
@@ -101,7 +106,7 @@ public actor DomainDB {
         return try? modelContext.fetch(descriptor).first
     }
 
-    public func name(of id: NSFileProviderItemIdentifier) throws -> String {
+    func name(of id: NSFileProviderItemIdentifier) throws -> String {
         guard let item = fetch(id: id) else {
             throw NSFileProviderError(.noSuchItem)
         }
@@ -126,7 +131,7 @@ public actor DomainDB {
         return item.id
     }
 
-    public func child(
+    func child(
         of parent: NSFileProviderItemIdentifier = .rootContainer,
         path: String,
         ifNotExists: OnNotExists = .create,
@@ -142,7 +147,7 @@ public actor DomainDB {
         return current
     }
 
-    public func parent(
+    func parent(
         of id: NSFileProviderItemIdentifier
     ) throws -> NSFileProviderItemIdentifier {
         guard let item = fetch(id: id) else {
@@ -152,7 +157,7 @@ public actor DomainDB {
         return item.parentId
     }
 
-    public func path(for id: NSFileProviderItemIdentifier) -> String {
+    func path(for id: NSFileProviderItemIdentifier) -> String {
         var current = id
         var segments: [String] = []
 
@@ -167,7 +172,7 @@ public actor DomainDB {
         return segments.reversed().joined(separator: "/")
     }
 
-    public func path(
+    func path(
         for name: String,
         in parentId: NSFileProviderItemIdentifier
     ) -> String {
@@ -175,7 +180,7 @@ public actor DomainDB {
         return parentPath.isEmpty ? name : parentPath + "/" + name
     }
 
-    public func move(
+    func move(
         _ id: NSFileProviderItemIdentifier,
         toParent newParentId: NSFileProviderItemIdentifier,
         name newName: String
@@ -188,7 +193,7 @@ public actor DomainDB {
         try modelContext.save()
     }
 
-    public func upsert(_ item: ItemModel) throws {
+    func upsert(_ item: ItemModel) throws {
         modelContext.insert(item)
         try modelContext.save()
     }

--- a/AgentKit/Session.swift
+++ b/AgentKit/Session.swift
@@ -62,10 +62,9 @@ class Session {
 
     func child(
         of parentId: NSFileProviderItemIdentifier = .rootContainer,
-        path: String,
-        ifNotExists: OnNotExists = .create
+        path: String
     ) async throws -> NSFileProviderItemIdentifier {
-        try await db.child(of: parentId, path: path, ifNotExists: ifNotExists)
+        try await db.child(of: parentId, path: path, ifNotExists: .fail)
     }
 
     func parent(
@@ -118,47 +117,40 @@ class Session {
     }
 
     func list(
-        for parentId: NSFileProviderItemIdentifier
-    ) async throws -> [Item] {
-        try await withDirectory(for: parentId) { dir in
-            var entries: [Item] = []
-            for try await attrs in dir {
-                guard let name = attrs.name else { continue }
-                let itemId = try await child(of: parentId, path: name)
-                let type: Item.Kind =
-                    switch attrs.type {
-                    case .directory:
-                        .folder
-                    case .symlink:
-                        .symlink(target: nil)
-                    default:
-                        .file
-                    }
-                let item = Item(
-                    id: itemId.rawValue,
-                    parentId: parentId.rawValue,
-                    name: name,
-                    kind: type,
-                    size: attrs.size,
-                    permissions: attrs.permissions,
-                    accessTime: attrs.accessTime,
-                    modifyTime: attrs.modifyTime,
-                    createTime: attrs.createTime
-                )
-                entries.append(item)
-            }
-            return entries
-        }
-    }
-
-    func exists(
         for itemId: NSFileProviderItemIdentifier
-    ) async -> Bool {
+    ) async throws -> [Item] {
         do {
-            _ = try await attributes(for: itemId)
-            return true
-        } catch {
-            return false
+            return try await withDirectory(for: itemId) { dir in
+                var entries: [Item] = []
+                for try await attrs in dir {
+                    guard let name = attrs.name else { continue }
+                    let childId = try await db.child(of: itemId, path: name)
+                    let type: Item.Kind =
+                        switch attrs.type {
+                        case .directory:
+                            .folder
+                        case .symlink:
+                            .symlink(target: nil)
+                        default:
+                            .file
+                        }
+                    let child = Item(
+                        id: childId.rawValue,
+                        parentId: itemId.rawValue,
+                        name: name,
+                        kind: type,
+                        size: attrs.size,
+                        permissions: attrs.permissions,
+                        accessTime: attrs.accessTime,
+                        modifyTime: attrs.modifyTime,
+                        createTime: attrs.createTime
+                    )
+                    entries.append(child)
+                }
+                return entries
+            }
+        } catch AgentError.itemNotFound where itemId == .trashContainer {
+            return []
         }
     }
 
@@ -280,8 +272,7 @@ class Session {
     func move(
         _ itemId: NSFileProviderItemIdentifier,
         toParent newParentId: NSFileProviderItemIdentifier,
-        name newName: String,
-        ifParentNotExists: OnParentNotExists = .fail
+        name newName: String
     ) async throws {
         let oldPath = await path(for: itemId)
         let newPath = await path(for: newName, parentId: newParentId)
@@ -291,9 +282,9 @@ class Session {
             do {
                 try await sftp.move(from: oldPath, to: newPath)
             } catch SSHError.sftpError(.noSuchFile, _)
-                where ifParentNotExists == .create
+                where newParentId == .trashContainer
             {
-                logger.info("Parent doesn't exist, creating")
+                logger.info("Trash doesn't exist, creating")
                 try await sftp.createDirectoryRecursively(
                     at: path(for: newParentId),
                     mode: 0o700
@@ -358,7 +349,8 @@ class Session {
                             throw AgentError.userCancelled
                         }
                         try await writer.write(data: data)
-                        if let progress = speedometer.update(delta: data.count) {
+                        if let progress = speedometer.update(delta: data.count)
+                        {
                             logger.debug("Uploading \(path): \(progress)")
                         }
                     }

--- a/AgentKitTests/SessionTests.swift
+++ b/AgentKitTests/SessionTests.swift
@@ -15,17 +15,43 @@ private func getSession() async throws -> Session {
         config: ModelConfiguration(isStoredInMemoryOnly: true)
     )
 
-    return Session(
+    let session = Session(
         config: config,
         ssh: ssh,
         sftp: sftp,
         db: db,
         sharedUrl: TestData.sharedUrl
     )
+
+    var folders: [NSFileProviderItemIdentifier] = [.rootContainer]
+    while !folders.isEmpty {
+        let folder = folders.removeFirst()
+        let items = try await session.list(for: folder)
+        for item in items {
+            if item.kind == .folder, (item.permissions ?? 0) & 0o400 != 0 {
+                folders.append(NSFileProviderItemIdentifier(item.id))
+            }
+        }
+    }
+
+    return session
 }
 
 struct SessionTests {
-    struct NameTests {
+    struct NameChildParentPathTests {
+        init() throws {
+            try TestData.createFile(path: "file.txt", contents: "")
+            try TestData.createFile(path: "folder/file.txt", contents: "")
+            try TestData.createFile(
+                path: "folder/subfolder/file.txt",
+                contents: ""
+            )
+            try TestData.createFile(
+                path: ".sshadow/trash/file.txt",
+                contents: ""
+            )
+        }
+
         @Test func filePropertyReturnsFilenameForSimpleItem() async throws {
             let session = try await getSession()
             let simpleFile = try await session.child(path: "file.txt")
@@ -39,9 +65,7 @@ struct SessionTests {
             let name = try await session.name(of: nestedFile)
             #expect(name == "file.txt")
         }
-    }
 
-    struct ParentTests {
         @Test func parentOfRootContainerIsRootContainer() async throws {
             let session = try await getSession()
             let parent = try await session.parent(of: .rootContainer)
@@ -64,7 +88,7 @@ struct SessionTests {
         @Test func parentOfItemInTrashIsTrashContainer() async throws {
             let session = try await getSession()
             let itemInTrashes = try await session.child(
-                path: ".sshadow/trash/file"
+                path: ".sshadow/trash/file.txt"
             )
             let parent = try await session.parent(of: itemInTrashes)
             #expect(parent == .trashContainer)
@@ -72,7 +96,7 @@ struct SessionTests {
 
         @Test func parentOfNestedItemIsParentFolder() async throws {
             let session = try await getSession()
-            let nested = try await session.child(path: "folder/file")
+            let nested = try await session.child(path: "folder/file.txt")
             let actual = try await session.parent(of: nested)
             let expected = try await session.child(path: "folder")
             #expect(actual == expected)
@@ -80,17 +104,15 @@ struct SessionTests {
 
         @Test func parentOfDeeplyNestedItemIsImmediateParent() async throws {
             let session = try await getSession()
-            let deeplyNested = try await session.child(path: "a/b/c")
+            let deeplyNested = try await session.child(
+                path: "folder/subfolder/file.txt"
+            )
             let actual = try await session.parent(of: deeplyNested)
-            let expected = try await session.child(path: "a/b")
+            let expected = try await session.child(path: "folder/subfolder")
             #expect(actual == expected)
         }
-    }
 
-    struct ChildTests {
-        @Test func childOfRootContainerWithNameTrashesIsTrashContainer()
-            async throws
-        {
+        @Test func trashFolderIsIsTrashContainer() async throws {
             let session = try await getSession()
             let childOfRoot = try await session.child(path: ".sshadow/trash")
             #expect(childOfRoot == .trashContainer)
@@ -100,10 +122,10 @@ struct SessionTests {
             let session = try await getSession()
             let actual = try await session.child(
                 of: .trashContainer,
-                path: "file"
+                path: "file.txt"
             )
             let expected = try await session.child(
-                path: ".sshadow/trash/file"
+                path: ".sshadow/trash/file.txt"
             )
             #expect(actual == expected)
         }
@@ -111,13 +133,11 @@ struct SessionTests {
         @Test func childOfItemReturnsNestedItem() async throws {
             let session = try await getSession()
             let parent = try await session.child(path: "folder")
-            let actual = try await session.child(of: parent, path: "file")
-            let expected = try await session.child(path: "folder/file")
+            let actual = try await session.child(of: parent, path: "file.txt")
+            let expected = try await session.child(path: "folder/file.txt")
             #expect(actual == expected)
         }
-    }
 
-    struct PathTests {
         @Test func pathForRootContainerReturnsConfigPath() async throws {
             let session = try await getSession()
             let path = await session.path(for: .rootContainer)
@@ -156,12 +176,11 @@ struct SessionTests {
         }
 
         @Test func itemForFileSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/file.txt"
             let contents = "Hello, World!"
             try TestData.createFile(path: path, contents: contents)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let item = try await session.item(for: itemId)
 
@@ -172,11 +191,10 @@ struct SessionTests {
         }
 
         @Test func itemForFolderSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/folder"
             try TestData.createFolder(path: path)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let item = try await session.item(for: itemId)
 
@@ -185,14 +203,13 @@ struct SessionTests {
         }
 
         @Test func itemForSymlinkSucceeds() async throws {
-            let session = try await getSession()
-
             let target = "\(testFolderPath)/item-symlink-target.txt"
             let contents = "Hello, World!"
             try TestData.createFile(path: target, contents: contents)
             let symlink = "\(testFolderPath)/item-symlink-link.txt"
             try TestData.createSymlink(path: symlink, target: target)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: symlink)
             let item = try await session.item(for: itemId)
 
@@ -201,11 +218,10 @@ struct SessionTests {
         }
 
         @Test func itemHasCorrectParent() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/nested/file.txt"
             try TestData.createFile(path: path, contents: "data")
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let parentId = try await session.child(
                 path: "\(testFolderPath)/nested"
@@ -224,8 +240,6 @@ struct SessionTests {
         }
 
         @Test func listReturnsFilesFoldersAndSymlinks() async throws {
-            let session = try await getSession()
-
             try TestData.createFile(
                 path: "\(testFolderPath)/file.txt",
                 contents: "hello"
@@ -238,6 +252,7 @@ struct SessionTests {
                 target: "file.txt"
             )
 
+            let session = try await getSession()
             let itemId = try await session.child(path: testFolderPath)
             let entries = try await session.list(for: itemId)
 
@@ -262,11 +277,10 @@ struct SessionTests {
         }
 
         @Test func listEmptyDirectoryReturnsEmpty() async throws {
-            let session = try await getSession()
-
             let emptyPath = "\(testFolderPath)/empty"
             try TestData.createFolder(path: emptyPath)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: emptyPath)
             let entries = try await session.list(for: itemId)
 
@@ -274,13 +288,12 @@ struct SessionTests {
         }
 
         @Test func listEntriesHaveCorrectParent() async throws {
-            let session = try await getSession()
-
             try TestData.createFile(
                 path: "\(testFolderPath)/child.txt",
                 contents: "data"
             )
 
+            let session = try await getSession()
             let parentId = try await session.child(path: testFolderPath)
             let entries = try await session.list(for: parentId)
 
@@ -288,35 +301,6 @@ struct SessionTests {
                 entries.first { $0.name == "child.txt" }
             )
             #expect(child.parentId == parentId.rawValue)
-        }
-    }
-
-    struct ExistsTests {
-        let testFolderPath = "session-exists"
-
-        init() throws {
-            try TestData.createFolder(path: testFolderPath)
-        }
-
-        @Test func existsReturnsTrueForExistingFile() async throws {
-            let session = try await getSession()
-
-            let path = "\(testFolderPath)/file.txt"
-            try TestData.createFile(path: path, contents: "data")
-
-            let itemId = try await session.child(path: path)
-            let result = await session.exists(for: itemId)
-            #expect(result == true)
-        }
-
-        @Test func existsReturnsFalseForMissingFile() async throws {
-            let session = try await getSession()
-
-            let itemId = try await session.child(
-                path: "\(testFolderPath)/missing.txt"
-            )
-            let result = await session.exists(for: itemId)
-            #expect(result == false)
         }
     }
 
@@ -329,12 +313,11 @@ struct SessionTests {
         }
 
         @Test func attributesForFileSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/file.txt"
             let contents = "Hello, World!"
             try TestData.createFile(path: path, contents: contents)
 
+            let session = try await getSession()
             let attrs = try await session.attributes(
                 for: session.child(path: path)
             )
@@ -344,11 +327,10 @@ struct SessionTests {
         }
 
         @Test func attributesForFolderSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/folder"
             try TestData.createFolder(path: path)
 
+            let session = try await getSession()
             let attrs = try await session.attributes(
                 for: session.child(path: path)
             )
@@ -357,17 +339,16 @@ struct SessionTests {
         }
 
         @Test func attributesForMissingFileThrowsNoSuchItem() async throws {
+            let path = "\(testFolderPath)/missing.txt"
+            let contents = "Hello, World!"
+            try TestData.createFile(path: path, contents: contents)
+
             let session = try await getSession()
+            let itemId = try await session.child(path: path)
+            try TestData.removeItem(path: path)
 
-            let parentId = try await session.child(path: testFolderPath)
-
-            await #expect(throws: AgentError.itemNotFound(parentId.rawValue)) {
-                try await session.attributes(
-                    for: session.child(
-                        path: "\(testFolderPath)/missing.txt",
-                        ifNotExists: .fail
-                    )
-                )
+            await #expect(throws: AgentError.itemNotFound(itemId.rawValue)) {
+                try await session.attributes(for: itemId)
             }
         }
     }
@@ -380,16 +361,12 @@ struct SessionTests {
         }
 
         @Test func setPermissionsSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/perms.txt"
             try TestData.createFile(path: path, contents: "test")
-            let itemId = try await session.child(path: path)
 
-            try await session.setAttributes(
-                for: itemId,
-                permissions: 0o644
-            )
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
+            try await session.setAttributes(for: itemId, permissions: 0o644)
 
             let attrs = try await session.attributes(for: itemId)
             let permissions = try #require(attrs.permissions)
@@ -397,52 +374,42 @@ struct SessionTests {
         }
 
         @Test func setModifyTimeSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/modify-time.txt"
             try TestData.createFile(path: path, contents: "test")
-            let itemId = try await session.child(path: path)
 
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
             let date = Date(timeIntervalSince1970: 1_000_000)
-            try await session.setAttributes(
-                for: itemId,
-                modifyTime: date
-            )
+            try await session.setAttributes(for: itemId, modifyTime: date)
 
             let attrs = try await session.attributes(for: itemId)
             #expect(attrs.modifyTime == date)
         }
 
         @Test func setAccessTimeSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/access-time.txt"
             try TestData.createFile(path: path, contents: "test")
-            let itemId = try await session.child(path: path)
 
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
             let date = Date(timeIntervalSince1970: 2_000_000)
-            try await session.setAttributes(
-                for: itemId,
-                accessTime: date
-            )
+            try await session.setAttributes(for: itemId, accessTime: date)
 
             let attrs = try await session.attributes(for: itemId)
             #expect(attrs.accessTime == date)
         }
 
         @Test func setAttributesForMissingFileThrows() async throws {
+            let path = "\(testFolderPath)/missing.txt"
+            let contents = "Hello, World!"
+            try TestData.createFile(path: path, contents: contents)
+
             let session = try await getSession()
+            let itemId = try await session.child(path: path)
+            try TestData.removeItem(path: path)
 
-            let parentId = try await session.child(path: testFolderPath)
-
-            await #expect(throws: AgentError.itemNotFound(parentId.rawValue)) {
-                try await session.setAttributes(
-                    for: session.child(
-                        path: "\(testFolderPath)/missing.txt",
-                        ifNotExists: .fail
-                    ),
-                    permissions: 0o644
-                )
+            await #expect(throws: AgentError.itemNotFound(itemId.rawValue)) {
+                try await session.setAttributes(for: itemId, permissions: 0o644)
             }
         }
     }
@@ -512,8 +479,7 @@ struct SessionTests {
             }
         }
 
-        @Test func createDirectorySuccessInsertsRowMatchingItemId() async throws
-        {
+        @Test func createDirectoryInsertsRowMatchingItemId() async throws {
             let session = try await getSession()
 
             let parentId = try await session.child(path: testFolderPath)
@@ -524,11 +490,7 @@ struct SessionTests {
                 name: name
             )
 
-            let lookedUpId = try await session.child(
-                of: parentId,
-                path: name,
-                ifNotExists: .fail
-            )
+            let lookedUpId = try await session.child(of: parentId, path: name)
             #expect(lookedUpId.rawValue == item.id)
         }
 
@@ -538,7 +500,6 @@ struct SessionTests {
             let parentId = try await session.child(path: testFolderPath)
             let name = "collide-dir"
 
-            // Pre-create on disk so SFTP createDirectory throws collision.
             try TestData.createFolder(path: "\(testFolderPath)/\(name)")
 
             await #expect(throws: AgentError.filenameCollision) {
@@ -548,15 +509,8 @@ struct SessionTests {
                 )
             }
 
-            // No DB row should exist for the failed create.
-            await #expect(
-                throws: AgentError.itemNotFound(parentId.rawValue)
-            ) {
-                _ = try await session.child(
-                    of: parentId,
-                    path: name,
-                    ifNotExists: .fail
-                )
+            await #expect(throws: AgentError.itemNotFound(parentId.rawValue)) {
+                _ = try await session.child(of: parentId, path: name)
             }
         }
     }
@@ -584,7 +538,7 @@ struct SessionTests {
             #expect(item.kind == .symlink(target: target))
         }
 
-        @Test func createSymlinkSuccessInsertsRowMatchingItemId() async throws {
+        @Test func createSymlinkInsertsRowMatchingItemId() async throws {
             let session = try await getSession()
 
             let parentId = try await session.child(path: testFolderPath)
@@ -596,11 +550,7 @@ struct SessionTests {
                 target: "/dev/null"
             )
 
-            let lookedUpId = try await session.child(
-                of: parentId,
-                path: name,
-                ifNotExists: .fail
-            )
+            let lookedUpId = try await session.child(of: parentId, path: name)
             #expect(lookedUpId.rawValue == item.id)
         }
 
@@ -610,7 +560,6 @@ struct SessionTests {
             let parentId = try await session.child(path: testFolderPath)
             let name = "collide-link"
 
-            // Pre-create the symlink file so SFTP createSymlink fails.
             try TestData.createFile(
                 path: "\(testFolderPath)/\(name)",
                 contents: "data"
@@ -624,14 +573,8 @@ struct SessionTests {
                 )
             }
 
-            await #expect(
-                throws: AgentError.itemNotFound(parentId.rawValue)
-            ) {
-                _ = try await session.child(
-                    of: parentId,
-                    path: name,
-                    ifNotExists: .fail
-                )
+            await #expect(throws: AgentError.itemNotFound(parentId.rawValue)) {
+                _ = try await session.child(of: parentId, path: name)
             }
         }
     }
@@ -644,10 +587,10 @@ struct SessionTests {
         }
 
         @Test func moveRenamesFile() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/original.txt"
             try TestData.createFile(path: path, contents: "hello")
+
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let parentId = try await session.child(path: testFolderPath)
 
@@ -658,22 +601,21 @@ struct SessionTests {
             )
 
             let newId = try await session.child(
-                path: "\(testFolderPath)/renamed.txt",
-                ifNotExists: .fail
+                path: "\(testFolderPath)/renamed.txt"
             )
+            #expect(itemId == newId)
             let attrs = try await session.attributes(for: newId)
             #expect(attrs.type == .regular)
         }
 
         @Test func moveToNewParent() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/to-move.txt"
             try TestData.createFile(path: path, contents: "hello")
-            let itemId = try await session.child(path: path)
-
             let destPath = "\(testFolderPath)/dest"
             try TestData.createFolder(path: destPath)
+
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
             let destId = try await session.child(path: destPath)
 
             try await session.move(
@@ -683,48 +625,21 @@ struct SessionTests {
             )
 
             let movedId = try await session.child(
-                path: "\(testFolderPath)/dest/to-move.txt",
-                ifNotExists: .fail
+                path: "\(testFolderPath)/dest/to-move.txt"
             )
-            let attrs = try await session.attributes(for: movedId)
-            #expect(attrs.type == .regular)
-        }
-
-        @Test func moveCreatesParentWhenRequested() async throws {
-            let session = try await getSession()
-
-            let path = "\(testFolderPath)/create-parent.txt"
-            try TestData.createFile(path: path, contents: "hello")
-            let itemId = try await session.child(path: path)
-
-            let newParentId = try await session.child(
-                path: "\(testFolderPath)/new-parent"
-            )
-
-            try await session.move(
-                itemId,
-                toParent: newParentId,
-                name: "create-parent.txt",
-                ifParentNotExists: .create
-            )
-
-            let movedId = try await session.child(
-                path: "\(testFolderPath)/new-parent/create-parent.txt",
-                ifNotExists: .fail
-            )
+            #expect(itemId == movedId)
             let attrs = try await session.attributes(for: movedId)
             #expect(attrs.type == .regular)
         }
 
         @Test func moveUpdatesDbParentAndName() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/db-check.txt"
             try TestData.createFile(path: path, contents: "hello")
-            let itemId = try await session.child(path: path)
-
             let destPath = "\(testFolderPath)/db-dest"
             try TestData.createFolder(path: destPath)
+
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
             let destId = try await session.child(path: destPath)
 
             try await session.move(
@@ -749,27 +664,27 @@ struct SessionTests {
         }
 
         @Test func removeFileSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/to-delete.txt"
             try TestData.createFile(path: path, contents: "bye")
-            let itemId = try await session.child(path: path)
 
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
             try await session.removeFile(for: itemId)
 
-            let exists = await session.exists(for: itemId)
-            #expect(!exists)
+            #expect(!TestData.exists(path: path))
         }
 
         @Test func removeFileMissingThrows() async throws {
+            let path = "\(testFolderPath)/nonexistent.txt"
+            try TestData.createFile(path: path, contents: "nothing")
+
             let session = try await getSession()
+            let itemId = try await session.child(path: path)
+            try await session.removeFile(for: itemId)
 
-            let itemId = try await session.child(
-                path: "\(testFolderPath)/nonexistent.txt"
-            )
-
-            let exists = await session.exists(for: itemId)
-            #expect(!exists)
+            await #expect(throws: AgentError.itemNotFound(itemId.rawValue)) {
+                try await session.removeFile(for: itemId)
+            }
         }
     }
 
@@ -781,32 +696,28 @@ struct SessionTests {
         }
 
         @Test func removeDirectorySucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/to-delete"
             try TestData.createFolder(path: path)
-            let itemId = try await session.child(path: path)
 
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
             try await session.removeDirectory(for: itemId)
 
-            let exists = await session.exists(for: itemId)
-            #expect(!exists)
+            #expect(!TestData.exists(path: path))
         }
 
         @Test func removeDirectoryWithContentsSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/non-empty"
             try TestData.createFile(
                 path: "\(path)/child.txt",
                 contents: "nested"
             )
-            let itemId = try await session.child(path: path)
 
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
             try await session.removeDirectory(for: itemId)
 
-            let exists = await session.exists(for: itemId)
-            #expect(!exists)
+            #expect(!TestData.exists(path: path))
         }
     }
 
@@ -819,8 +730,6 @@ struct SessionTests {
         }
 
         @Test func uploadSmallFileSucceeds() async throws {
-            let session = try await getSession()
-
             let uploadUrl = FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString)
             let data = "Hello, World!\n"
@@ -831,6 +740,7 @@ struct SessionTests {
             try TestData.removeItem(path: filePath)
             let url = TestData.getUrl(path: filePath)
 
+            let session = try await getSession()
             let parentId = try await session.child(path: testFolderPath)
             let progress = Progress()
             let item = try await session.upload(
@@ -840,6 +750,7 @@ struct SessionTests {
                 mode: 0o600,
                 progress: progress
             )
+            let currId = try await session.child(of: parentId, path: filename)
 
             #expect(item.name == filename)
             #expect(item.size == UInt64(data.utf8.count))
@@ -847,11 +758,10 @@ struct SessionTests {
             #expect(try String(contentsOf: url, encoding: .utf8) == data)
             #expect(progress.isFinished)
             #expect(try FileManager.default.permissions(of: url) == 0o600)
+            #expect(currId.rawValue == item.id)
         }
 
         @Test func uploadLargeFileSucceeds() async throws {
-            let session = try await getSession()
-
             let uploadUrl = FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString)
             let data = Data(count: 10_485_760)
@@ -862,6 +772,7 @@ struct SessionTests {
             try TestData.removeItem(path: filePath)
             let url = TestData.getUrl(path: filePath)
 
+            let session = try await getSession()
             let parentId = try await session.child(path: testFolderPath)
             let progress = Progress()
             let item = try await session.upload(
@@ -871,6 +782,7 @@ struct SessionTests {
                 mode: 0o600,
                 progress: progress
             )
+            let currId = try await session.child(of: parentId, path: filename)
 
             #expect(item.name == filename)
             #expect(item.size == UInt64(data.count))
@@ -878,34 +790,7 @@ struct SessionTests {
             #expect(try Data(contentsOf: url) == data)
             #expect(progress.isFinished)
             #expect(try FileManager.default.permissions(of: url) == 0o600)
-        }
-
-        @Test func uploadSuccessInsertsRowMatchingItemId() async throws {
-            let session = try await getSession()
-
-            let parentId = try await session.child(path: testFolderPath)
-            let name = "row-match-upload.txt"
-
-            let uploadUrl = FileManager.default.temporaryDirectory
-                .appending(path: UUID().uuidString)
-            try Data("data".utf8).write(to: uploadUrl)
-
-            try TestData.removeItem(path: "\(testFolderPath)/\(name)")
-
-            let item = try await session.upload(
-                parentId: parentId,
-                name: name,
-                file: uploadUrl,
-                mode: 0o600,
-                progress: Progress()
-            )
-
-            let lookedUpId = try await session.child(
-                of: parentId,
-                path: name,
-                ifNotExists: .fail
-            )
-            #expect(lookedUpId.rawValue == item.id)
+            #expect(currId.rawValue == item.id)
         }
 
         @Test func uploadFailureLeavesNoRow() async throws {
@@ -932,20 +817,12 @@ struct SessionTests {
                 )
             }
 
-            await #expect(
-                throws: AgentError.itemNotFound(parentId.rawValue)
-            ) {
-                _ = try await session.child(
-                    of: parentId,
-                    path: name,
-                    ifNotExists: .fail
-                )
+            await #expect(throws: AgentError.itemNotFound(parentId.rawValue)) {
+                _ = try await session.child(of: parentId, path: name)
             }
         }
 
         @Test func uploadEmptyFileSucceeds() async throws {
-            let session = try await getSession()
-
             let uploadUrl = FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString)
             try Data().write(to: uploadUrl)
@@ -955,6 +832,7 @@ struct SessionTests {
             try TestData.removeItem(path: filePath)
             let url = TestData.getUrl(path: filePath)
 
+            let session = try await getSession()
             let parentId = try await session.child(path: testFolderPath)
             let progress = Progress()
             let item = try await session.upload(
@@ -964,6 +842,7 @@ struct SessionTests {
                 mode: 0o600,
                 progress: progress
             )
+            let currId = try await session.child(of: parentId, path: filename)
 
             #expect(item.name == filename)
             #expect(item.size == 0)
@@ -971,6 +850,7 @@ struct SessionTests {
             #expect(try Data(contentsOf: url).isEmpty)
             #expect(progress.isFinished)
             #expect(try FileManager.default.permissions(of: url) == 0o600)
+            #expect(currId.rawValue == item.id)
         }
     }
 
@@ -983,12 +863,11 @@ struct SessionTests {
         }
 
         @Test func downloadSmallFileSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/small-file.txt"
             let data = "Hello, World!"
             try TestData.createFile(path: path, contents: data)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let progress = Progress()
             let (url, item) = try await session.download(
@@ -1005,12 +884,11 @@ struct SessionTests {
         }
 
         @Test func downloadLargeFileSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/large-file.dat"
             let data = Data(count: 10_485_760)
             try TestData.createFile(path: path, data: data)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let progress = Progress()
             let (url, item) = try await session.download(
@@ -1026,11 +904,10 @@ struct SessionTests {
         }
 
         @Test func downloadEmptyFileSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/empty-file.txt"
             try TestData.createFile(path: path, contents: "")
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let progress = Progress()
             let (url, item) = try await session.download(
@@ -1054,12 +931,11 @@ struct SessionTests {
         }
 
         @Test func streamSmallFileSucceeds() async throws {
-            let session = try await getSession()
-
             let data = Data(repeating: 0xAB, count: Int(chunkSize))
             let path = "\(testFolderPath)/small.dat"
             try TestData.createFile(path: path, data: data)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let progress = Progress()
             let (url, range) = try await session.stream(
@@ -1074,11 +950,10 @@ struct SessionTests {
         }
 
         @Test func streamEmptyFileSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/empty.dat"
             try TestData.createFile(path: path, data: Data())
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let progress = Progress()
             let (url, range) = try await session.stream(
@@ -1093,12 +968,11 @@ struct SessionTests {
         }
 
         @Test func streamExpandsRangeToChunkBoundary() async throws {
-            let session = try await getSession()
-
             let data = Data(count: Int(chunkSize) * 2)
             let path = "\(testFolderPath)/two-chunk-range.dat"
             try TestData.createFile(path: path, data: data)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let requestedRange = (chunkSize + 100)..<(chunkSize + 200)
             let (_, range) = try await session.stream(
@@ -1113,8 +987,6 @@ struct SessionTests {
         }
 
         @Test func streamWritesDataAtCorrectOffset() async throws {
-            let session = try await getSession()
-
             // Two-chunk file: first chunk 0xAA, second chunk 0xBB
             let data =
                 Data(repeating: 0xAA, count: Int(chunkSize))
@@ -1122,6 +994,7 @@ struct SessionTests {
             let path = "\(testFolderPath)/offset.dat"
             try TestData.createFile(path: path, data: data)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: path)
             let requestedRange = (chunkSize + 100)..<(chunkSize + 200)
             let (url, _) = try await session.stream(
@@ -1152,12 +1025,11 @@ struct SessionTests {
         }
 
         @Test func withFileReadSucceeds() async throws {
-            let session = try await getSession()
-
             let path = "\(testFolderPath)/read-file.txt"
             let contents = "Hello, World!"
             try TestData.createFile(path: path, contents: contents)
 
+            let session = try await getSession()
             let data = try await session.withFile(
                 for: session.child(path: path),
                 accessType: .readOnly
@@ -1169,11 +1041,13 @@ struct SessionTests {
         }
 
         @Test func withFileMissingFileThrowsNoSuchItem() async throws {
-            let session = try await getSession()
+            let path = "\(testFolderPath)/missing.txt"
+            let contents = "Hello, World!"
+            try TestData.createFile(path: path, contents: contents)
 
-            let itemId = try await session.child(
-                path: "\(testFolderPath)/missing.txt"
-            )
+            let session = try await getSession()
+            let itemId = try await session.child(path: path)
+            try TestData.removeItem(path: path)
 
             await #expect(throws: AgentError.itemNotFound(itemId.rawValue)) {
                 try await session.withFile(for: itemId, accessType: .readOnly) {
@@ -1191,14 +1065,13 @@ struct SessionTests {
         }
 
         @Test func withDirectoryListsEntries() async throws {
-            let session = try await getSession()
-
             try TestData.createFile(
                 path: "\(testFolderPath)/file.txt",
                 contents: "hello"
             )
             try TestData.createFolder(path: "\(testFolderPath)/subfolder")
 
+            let session = try await getSession()
             let itemId = try await session.child(path: testFolderPath)
             let names = try await session.withDirectory(for: itemId) { dir in
                 var names: [String] = []
@@ -1215,11 +1088,10 @@ struct SessionTests {
         }
 
         @Test func withDirectoryEmptyDirYieldsNothing() async throws {
-            let session = try await getSession()
-
             let emptyPath = "\(testFolderPath)/empty"
             try TestData.createFolder(path: emptyPath)
 
+            let session = try await getSession()
             let itemId = try await session.child(path: emptyPath)
             let count = try await session.withDirectory(for: itemId) { dir in
                 var count = 0

--- a/Common/AgentClient.swift
+++ b/Common/AgentClient.swift
@@ -93,16 +93,14 @@ public class AgentClient {
 
     public func child(
         of parentId: NSFileProviderItemIdentifier = .rootContainer,
-        path: String,
-        ifNotExists: OnNotExists = .create
+        path: String
     ) async throws -> NSFileProviderItemIdentifier {
         let reply = try await perform(
             .child(
                 ChildRequest(
                     domainId: domainId,
                     parentId: parentId.rawValue,
-                    path: path,
-                    ifNotExists: ifNotExists
+                    path: path
                 )
             )
         )
@@ -193,20 +191,6 @@ public class AgentClient {
         return response.fileInfos
     }
 
-    public func exists(
-        for itemId: NSFileProviderItemIdentifier
-    ) async throws -> Bool {
-        let reply = try await perform(
-            .exists(
-                ExistsRequest(domainId: domainId, itemId: itemId.rawValue)
-            )
-        )
-        guard case .exists(let response) = reply else {
-            throw CocoaError(.coderInvalidValue)
-        }
-        return response.exists
-    }
-
     public func setAttributes(
         for itemId: NSFileProviderItemIdentifier,
         permissions: mode_t? = nil,
@@ -276,8 +260,7 @@ public class AgentClient {
     public func move(
         _ itemId: NSFileProviderItemIdentifier,
         toParent newParentId: NSFileProviderItemIdentifier,
-        name newName: String,
-        ifParentNotExists: OnParentNotExists = .fail
+        name newName: String
     ) async throws {
         let reply = try await perform(
             .move(
@@ -285,8 +268,7 @@ public class AgentClient {
                     domainId: domainId,
                     itemId: itemId.rawValue,
                     newParentId: newParentId.rawValue,
-                    newName: newName,
-                    ifParentNotExists: ifParentNotExists
+                    newName: newName
                 )
             )
         )

--- a/Common/AgentProtocol.swift
+++ b/Common/AgentProtocol.swift
@@ -8,16 +8,6 @@ public enum OnExists: Codable, PrettyDescribable {
     case succeed
 }
 
-public enum OnNotExists: Codable, PrettyDescribable {
-    case fail
-    case create
-}
-
-public enum OnParentNotExists: Codable, PrettyDescribable {
-    case fail
-    case create
-}
-
 public enum AgentRequest: Codable, PrettyDescribable {
     public var domainId: UUID {
         switch self {
@@ -38,8 +28,6 @@ public enum AgentRequest: Codable, PrettyDescribable {
         case .item(let request):
             request.domainId
         case .list(let request):
-            request.domainId
-        case .exists(let request):
             request.domainId
         case .setAttributes(let request):
             request.domainId
@@ -73,7 +61,6 @@ public enum AgentRequest: Codable, PrettyDescribable {
     case pathForChild(PathForChildRequest)
     case item(ItemRequest)
     case list(ListRequest)
-    case exists(ExistsRequest)
     case setAttributes(SetAttributesRequest)
     case createSymlink(CreateSymlinkRequest)
     case createDirectory(CreateDirectoryRequest)
@@ -107,7 +94,6 @@ public enum AgentResponse: Codable, PrettyDescribable {
     case path(PathResponse)
     case item(ItemResponse)
     case list(ListResponse)
-    case exists(ExistsResponse)
     case setAttributes(SetAttributesResponse)
     case createSymlink(CreateSymlinkResponse)
     case createDirectory(CreateDirectoryResponse)
@@ -220,18 +206,15 @@ public struct ChildRequest: Codable, PrettyDescribable {
     public let domainId: UUID
     public let parentId: String
     public let path: String
-    public let ifNotExists: OnNotExists
 
     public init(
         domainId: UUID,
         parentId: String,
         path: String,
-        ifNotExists: OnNotExists
     ) {
         self.domainId = domainId
         self.parentId = parentId
         self.path = path
-        self.ifNotExists = ifNotExists
     }
 }
 
@@ -327,24 +310,6 @@ public struct ListResponse: Codable, PrettyDescribable {
     }
 }
 
-public struct ExistsRequest: Codable, PrettyDescribable {
-    public let domainId: UUID
-    public let itemId: String
-
-    public init(domainId: UUID, itemId: String) {
-        self.domainId = domainId
-        self.itemId = itemId
-    }
-}
-
-public struct ExistsResponse: Codable, PrettyDescribable {
-    let exists: Bool
-
-    public init(exists: Bool) {
-        self.exists = exists
-    }
-}
-
 public struct SetAttributesRequest: Codable, PrettyDescribable {
     public let domainId: UUID
     public let itemId: String
@@ -433,20 +398,17 @@ public struct MoveRequest: Codable, PrettyDescribable {
     public let itemId: String
     public let newParentId: String
     public let newName: String
-    public let ifParentNotExists: OnParentNotExists
 
     public init(
         domainId: UUID,
         itemId: String,
         newParentId: String,
-        newName: String,
-        ifParentNotExists: OnParentNotExists
+        newName: String
     ) {
         self.domainId = domainId
         self.itemId = itemId
         self.newParentId = newParentId
         self.newName = newName
-        self.ifParentNotExists = ifParentNotExists
     }
 }
 

--- a/CommonTests/AgentClientTests.swift
+++ b/CommonTests/AgentClientTests.swift
@@ -9,48 +9,58 @@ private func getAgentClient() async throws -> AgentClient {
     try await TestData.getAgentClient()
 }
 
+@Suite(.serialized)
 struct AgentClientTests {
-    let testFolderPath = "agent-client"
-    let testFolderUrl: URL
+    let testFolderPath: String = "agent-client"
 
     init() throws {
-        testFolderUrl = try TestData.createFolder(path: testFolderPath)
+        try TestData.createFolder(path: testFolderPath)
+        try TestData.createFile(
+            path: "agent-client/folder/file.txt",
+            contents: "Hello, World!"
+        )
     }
 
     @Test func nameAndChildAndParentSucceed() async throws {
         let agent = try await getAgentClient()
 
-        let nestedFile = try await agent.child(path: "folder/file")
+        let nestedFile = try await agent.child(
+            path: "agent-client/folder/file.txt"
+        )
         let nestedFileName = try await agent.name(of: nestedFile)
-        #expect(nestedFileName == "file")
+        #expect(nestedFileName == "file.txt")
 
         let parentOfFileId = try await agent.parent(of: nestedFile)
-        let childOfRootId = try await agent.child(path: "folder")
+        let childOfRootId = try await agent.child(path: "agent-client/folder")
         #expect(parentOfFileId == childOfRootId)
     }
 
     @Test func pathForItemSucceeds() async throws {
         let agent = try await getAgentClient()
-        let itemId = try await agent.child(path: "folder/file.txt")
+        let itemId = try await agent.child(path: "agent-client/folder/file.txt")
+
         let path = try await agent.path(for: itemId)
-        #expect(path.hasSuffix("/folder/file.txt"))
+
+        #expect(path.hasSuffix("agent-client/folder/file.txt"))
     }
 
     @Test func pathForChildSucceeds() async throws {
         let agent = try await getAgentClient()
-        let parentId = try await agent.child(path: "folder")
+        let parentId = try await agent.child(path: "agent-client/folder")
+
         let path = try await agent.path(for: "file.txt", parentId: parentId)
-        #expect(path.hasSuffix("/folder/file.txt"))
+
+        #expect(path.hasSuffix("agent-client/folder/file.txt"))
     }
 
     @Test func itemForFileSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let path = "\(testFolderPath)/item-file.txt"
         let contents = "Hello, World!"
         try TestData.createFile(path: path, contents: contents)
 
+        let agent = try await getAgentClient()
         let itemId = try await agent.child(path: path)
+
         let item = try await agent.item(for: itemId)
 
         #expect(item.name == "item-file.txt")
@@ -59,12 +69,12 @@ struct AgentClientTests {
     }
 
     @Test func itemForFolderSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let path = "\(testFolderPath)/item-dir"
         try TestData.createFolder(path: path)
 
+        let agent = try await getAgentClient()
         let itemId = try await agent.child(path: path)
+
         let item = try await agent.item(for: itemId)
 
         #expect(item.name == "item-dir")
@@ -72,15 +82,15 @@ struct AgentClientTests {
     }
 
     @Test func itemForSymlinkSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let target = "\(testFolderPath)/item-symlink-target.txt"
         let contents = "Hello, World!"
         try TestData.createFile(path: target, contents: contents)
         let symlink = "\(testFolderPath)/item-symlink-link.txt"
         try TestData.createSymlink(path: symlink, target: target)
 
+        let agent = try await getAgentClient()
         let itemId = try await agent.child(path: symlink)
+
         let item = try await agent.item(for: itemId)
 
         #expect(item.name == "item-symlink-link.txt")
@@ -88,8 +98,6 @@ struct AgentClientTests {
     }
 
     @Test func listSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let dirPath = "\(testFolderPath)/enum-dir"
         try TestData.createFile(
             path: "\(dirPath)/file.txt",
@@ -97,7 +105,9 @@ struct AgentClientTests {
         )
         try TestData.createFolder(path: "\(dirPath)/subfolder")
 
+        let agent = try await getAgentClient()
         let dirId = try await agent.child(path: dirPath)
+
         let entries = try await agent.list(for: dirId)
 
         let names = Set(entries.map(\.name))
@@ -114,37 +124,37 @@ struct AgentClientTests {
     }
 
     @Test func listEmptyDirectorySucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let dirPath = "\(testFolderPath)/empty-dir"
         try TestData.createFolder(path: dirPath)
 
+        let agent = try await getAgentClient()
         let dirId = try await agent.child(path: dirPath)
+
         let entries = try await agent.list(for: dirId)
 
         #expect(entries.isEmpty)
     }
 
     @Test func setAttributesSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let path = "\(testFolderPath)/set-attrs.txt"
         try TestData.createFile(path: path, contents: "test")
+
+        let agent = try await getAgentClient()
         let itemId = try await agent.child(path: path)
 
         try await agent.setAttributes(for: itemId, permissions: 0o644)
+
         let item = try await agent.item(for: itemId)
-        
+
         let permissions = try #require(item.permissions)
         #expect(permissions & 0o777 == 0o644)
     }
 
     @Test func createSymlinkSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let target = "\(testFolderPath)/symlink-target.txt"
         try TestData.createFile(path: target, contents: "hello")
 
+        let agent = try await getAgentClient()
         let parentId = try await agent.child(path: testFolderPath)
 
         let item = try await agent.createSymlink(
@@ -173,10 +183,10 @@ struct AgentClientTests {
     }
 
     @Test func moveSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let path = "\(testFolderPath)/move-me.txt"
         try TestData.createFile(path: path, contents: "hello")
+
+        let agent = try await getAgentClient()
         let itemId = try await agent.child(path: path)
         let parentId = try await agent.child(path: testFolderPath)
 
@@ -191,29 +201,27 @@ struct AgentClientTests {
     }
 
     @Test func removeFileSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let path = "\(testFolderPath)/rm-file.txt"
-        try TestData.createFile(path: path, contents: "bye")
+        let file = try TestData.createFile(path: path, contents: "bye")
+
+        let agent = try await getAgentClient()
         let itemId = try await agent.child(path: path)
 
         try await agent.removeFile(for: itemId)
-        let exists = try await agent.exists(for: itemId)
 
-        #expect(exists == false)
+        #expect(!FileManager.default.fileExists(at: file))
     }
 
     @Test func removeDirectorySucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let path = "\(testFolderPath)/rm-dir"
-        try TestData.createFolder(path: path)
+        let folder = try TestData.createFolder(path: path)
+
+        let agent = try await getAgentClient()
         let itemId = try await agent.child(path: path)
 
         try await agent.removeDirectory(for: itemId)
-        let exists = try await agent.exists(for: itemId)
 
-        #expect(exists == false)
+        #expect(!FileManager.default.fileExists(at: folder))
     }
 
     @Test func limitsSucceeds() async throws {
@@ -247,11 +255,11 @@ struct AgentClientTests {
     }
 
     @Test func downloadSucceeds() async throws {
-        let agent = try await getAgentClient()
-
         let path = "\(testFolderPath)/download.txt"
         let contents = "download me"
         try TestData.createFile(path: path, contents: contents)
+
+        let agent = try await getAgentClient()
         let itemId = try await agent.child(path: path)
 
         let (url, fileInfo) = try await agent.download(

--- a/CommonTests/TestData.swift
+++ b/CommonTests/TestData.swift
@@ -117,15 +117,32 @@ enum TestData {
         )
         testListener = listener
         let session = try! XPCSession(endpoint: listener.endpoint)
-        return AgentClient(
+        let agent = AgentClient(
             domainId: id,
             session: session,
             sharedUrl: sharedUrl
         )
+
+        var folders: [NSFileProviderItemIdentifier] = [.rootContainer]
+        while !folders.isEmpty {
+            let folder = folders.removeFirst()
+            let items = try await agent.list(for: folder)
+            for item in items {
+                if item.kind == .folder, (item.permissions ?? 0) & 0o400 != 0 {
+                    folders.append(NSFileProviderItemIdentifier(item.id))
+                }
+            }
+        }
+
+        return agent
     }
 
     static func getUrl(path: String) -> URL {
         mount.appending(path: path)
+    }
+    
+    static func exists(path: String) -> Bool {
+        FileManager.default.fileExists(at: getUrl(path: path))
     }
 
     @discardableResult

--- a/ENUMERATION_PLAN.md
+++ b/ENUMERATION_PLAN.md
@@ -1,91 +1,45 @@
 # Enumeration & Change Tracking Plan
 
-Tracking doc for fleshing out FileProvider enumeration end-to-end: real sync
-anchors, `enumerateChanges`, working-set enumeration, and Agent-side polling
-for remote changes. Designed to span multiple PRs and multiple AI sessions.
+Tracking doc for fleshing out FileProvider enumeration end-to-end: real sync anchors, `enumerateChanges`, working-set enumeration, and Agent-side polling for remote changes. Designed to span multiple PRs and multiple AI sessions.
 
 ## Goal
 
-Today `SSHadow/ExtensionKit/Enumerator.swift` only implements `enumerateItems`
-for ordinary directories. The sync anchor is a constant, `enumerateChanges` is
-a no-op, and `.workingSet` enumeration returns nothing. We want macOS to learn
-about remote changes (new files, deletes, mtime bumps) without the user having
-to manually re-navigate into a directory.
+Today `SSHadow/ExtensionKit/Enumerator.swift` only implements `enumerateItems` for ordinary directories. The sync anchor is a constant, `enumerateChanges` is a no-op, and `.workingSet` enumeration returns nothing. We want macOS to learn
+about remote changes (new files, deletes, mtime bumps) without the user having to manually re-navigate into a directory.
 
 ## Architectural decisions
 
-- **`ItemModel` becomes the persisted twin of `Item`.** Same fields
-  (`kind`, `size`, `permissions`, `accessTime`, `modifyTime`, `createTime`)
-  stored as SwiftData columns, not via a separate `ItemSnapshot` table. The
-  1:1 cardinality makes a side-table pure overhead. `Item` stays the
-  XPC/boundary type — they can't be *one* type because `Item` is a Codable
-  struct shared with the extension while `@Model` requires a class in
-  `AgentKit` with associated-value enum flattening. A bridge
-  (`ItemModel.init(from: Item)` + `ItemModel.toItem()`) keeps the field
-  shapes in sync. This migration lands first (steps 1 + 2) because every
-  downstream piece reads or writes these fields.
-- **Create RPCs return `Item`, not take `itemId`.**
-  `createDirectory(parentId:, name:, mode:)`, `createSymlink(parentId:, name:, target:)`,
-  `upload(parentId:, name:, file:, mode:, progress:)` each do the SFTP op,
-  stat the result, insert a fully-populated `ItemModel`, and return the
-  `Item`. Atomic on the success path; nothing written on failure. This
-  eliminates the "reservation `ItemModel`" lifecycle (allocated by the
-  extension before the file exists, orphaned on create failure) and lets
-  snapshot fields be non-optional.
-- **Virtual containers (`.rootContainer`, `.workingSet`,
-  `.sshadowContainer`, `.trashContainer`)** keep a sentinel `kind = .folder`
-  with other snapshot fields `nil`. Polling filters them by id.
-- **Pull-style change delivery.** Agent writes change records to `DomainDB`
-  and pokes the extension via `NSFileProviderManager.signalEnumerator(for:)`.
-  The extension calls `enumerateChanges` on its own schedule and reads the
-  journal. No long-lived XPC stream. Open question: how fast does macOS
-  actually spin the extension up after a signal? Measure during step 6.
-- **Anchors are per-domain monotonic `UInt64`**, persisted in `DomainDB`,
-  serialized into `NSFileProviderSyncAnchor` as big-endian `Data`.
+- **`ItemModel` becomes the persisted twin of `Item`.** Same fields (`kind`, `size`, `permissions`, `accessTime`, `modifyTime`, `createTime`) stored as SwiftData columns, not via a separate `ItemSnapshot` table. The 1:1 cardinality makes a side-table pure overhead. `Item` stays the XPC/boundary type — they can't be _one_ type because `Item` is a Codable struct shared with the extension while `@Model` requires a class in `AgentKit` with associated-value enum flattening. A bridge (`ItemModel.init(from: Item)` + `ItemModel.toItem()`) keeps the field shapes in sync. This migration lands first (steps 1 + 2) because every downstream piece reads or writes these fields.
+- **Create RPCs return `Item`, not take `itemId`.** `createDirectory(parentId:, name:, mode:)`, `createSymlink(parentId:, name:, target:)`, `upload(parentId:, name:, file:, mode:, progress:)` each do the SFTP op, stat the result, insert a fully-populated `ItemModel`, and return the `Item`. Atomic on the success path; nothing written on failure. This eliminates the "reservation `ItemModel`" lifecycle (allocated by the extension before the file exists, orphaned on create failure) and lets snapshot fields be non-optional.
+- **Virtual containers (`.rootContainer`, `.workingSet`, `.sshadowContainer`, `.trashContainer`)** keep a sentinel `kind = .folder` with other snapshot fields `nil`. Polling filters them by id.
+- **Pull-style change delivery.** Agent writes change records to `DomainDB` and pokes the extension via `NSFileProviderManager.signalEnumerator(for:)`. The extension calls `enumerateChanges` on its own schedule and reads the journal. No long-lived XPC stream. Open question: how fast does macOS actually spin the extension up after a signal? Measure during step 6.
+- **Anchors are per-domain monotonic `UInt64`**, persisted in `DomainDB`, serialized into `NSFileProviderSyncAnchor` as big-endian `Data`.
 - **Journal is append-only.** Add pruning in step 7; unbounded for v1.
-- **Working-set membership is materialization-driven.** Any item the
-  extension has handed to macOS via `list`/`fetchContents` is in the
-  working set until evicted. Tracked via a `workingSet: Bool` column on
-  `ItemModel`.
+- **Working-set membership is materialization-driven.** Any item the extension has handed to macOS via `list`/`fetchContents` is in the working set until evicted. Tracked via a `workingSet: Bool` column on `ItemModel`.
 
 ## Concrete pieces
 
-Each step is intended to be one PR. Mark `[x]` and include the PR number once
-merged so future sessions can `git log` for context. Steps 1 and 2 are the
-prerequisite migration and could land as a single PR if small.
+Each step is intended to be one PR. Mark `[x]` and include the PR number once merged so future sessions can `git log` for context. Steps 1 and 2 are the prerequisite migration and could land as a single PR if small.
 
 ### Step 0 — Rename `PathNode` → `ItemModel`
 
 Mechanical rename, kept as its own PR so the step 1/2 diffs stay focused.
 
-- [x] Rename `SSHadow/AgentKit/PathNode.swift` → `ItemModel.swift` and the
-      `PathNode` class → `ItemModel`.
-- [x] Rename `SSHadow/AgentKitTests/PathNodeTests.swift` →
-      `ItemModelTests.swift`.
-- [x] Update all call sites (24 references across `DomainDB`, tests, and
-      `CLAUDE.md`).
+- [x] Rename `SSHadow/AgentKit/PathNode.swift` → `ItemModel.swift` and the `PathNode` class → `ItemModel`.
+- [x] Rename `SSHadow/AgentKitTests/PathNodeTests.swift` → `ItemModelTests.swift`.
+- [x] Update all call sites (24 references across `DomainDB`, tests, and `CLAUDE.md`).
 
 ### Step 1 — Create RPCs return `Item`
 
 Pure protocol + lifecycle refactor; no schema change. Establishes the
 invariant "every `ItemModel` row is server-confirmed," which step 2 relies on.
 
-- [x] Change RPC signatures in `Common/AgentProtocol.swift` and
-      `Common/AgentClient.swift` from `(itemId, …)` to
-      `(parentId, name, …) -> Item`:
-      `createDirectory`, `createSymlink`, `upload`.
-- [x] In `Session`, each operation: resolve parent path → run SFTP op →
-      stat → insert `ItemModel(id: UUID, parentId, name)` → return `Item`.
-- [x] Update `Extension.createItem` (Extension.swift:202-278): drop the
-      upfront `agent.child(...)`, call the new RPC, return the resulting
-      `Item` directly. The trailing `item(for: itemIdentifier)` lookup
-      goes away.
-- [x] Leave `Session.list()`'s `child(of:path:)` call (Session.swift:127)
-      alone — it has full metadata at hand and writes a real `ItemModel`.
-- [x] Tests: failed create leaves zero new rows; successful create leaves
-      exactly one row matching the returned `Item.id`.
-- [x] Migrate existing tests that use `child(...,.create)` to fabricate
-      ids for files they then create — they should use the new RPCs.
+- [x] Change RPC signatures in `Common/AgentProtocol.swift` and `Common/AgentClient.swift` from `(itemId, …)` to `(parentId, name, …) -> Item`: `createDirectory`, `createSymlink`, `upload`.
+- [x] In `Session`, each operation: resolve parent path → run SFTP op → stat → insert `ItemModel(id: UUID, parentId, name)` → return `Item`.
+- [x] Update `Extension.createItem` (Extension.swift:202-278): drop the upfront `agent.child(...)`, call the new RPC, return the resulting `Item` directly. The trailing `item(for: itemIdentifier)` lookup goes away.
+- [x] Leave `Session.list()`'s `child(of:path:)` call (Session.swift:127) alone — it has full metadata at hand and writes a real `ItemModel`.
+- [x] Tests: failed create leaves zero new rows; successful create leaves exactly one row matching the returned `Item.id`.
+- [x] Migrate existing tests that use `child(...,.create)` to fabricate ids for files they then create — they should use the new RPCs.
 
 **Follow-up (separate PR):** With the create RPCs owning row insertion,
 `AgentClient.child`'s `ifNotExists: .create` mode is no longer needed by
@@ -94,12 +48,16 @@ production callers. The only remaining caller is `Extension.setAttributes`
 `Session.list` still upserts by name internally via `db.child`, which is
 unaffected. Plan:
 
-- [ ] Drop `ifNotExists` from `AgentClient.child` / `ChildRequest` (always
-      `.fail`); rename to something like `lookup` if a clearer name helps.
-- [ ] Migrate test scaffolding that currently fabricates ids via
-      `agent.child(path: ...)` to either `agent.list(for: parentId)` +
-      pick-by-name, or to the create RPCs when the test itself is creating
-      the file.
+- [x] Drop `ifNotExists` from `AgentClient.child` / `ChildRequest` (always `.fail`); rename to something like `lookup` if a clearer name helps.
+  - [x] Drop ifNotExists from ChildRequest in AgentProtocol.swift
+  - [x] Drop ifNotExists from AgentClient.child
+  - [x] Update Agent.child handler to drop ifNotExists
+  - [x] Drop ifNotExists from Session.child; update Session.list to use db.child
+- [x] Migrate test scaffolding that currently fabricates ids via `agent.child(path: ...)` to either `agent.list(for: parentId)` + pick-by-name, or to the create RPCs when the test itself is creating the file.
+  - [x] Migrate SessionTests scaffolding
+  - [x] Migrate AgentClientTests scaffolding
+  - [x] Migrate ExtensionTests scaffolding
+  - [x] Migrate EnumeratorTests scaffolding
 
 **Acceptance:** failing a create leaves no row in `ItemModel`; a
 successful create leaves exactly one row with `(id, parentId, name)`
@@ -107,22 +65,15 @@ populated. Snapshot fields land in step 2.
 
 ### Step 2 — Snapshot file metadata on `ItemModel`
 
-- [ ] Add fields to `ItemModel`: `kind` (non-optional), `size`,
-      `permissions`, `accessTime`, `modifyTime`, `createTime` (optionality
-      matching `Item`).
-- [ ] In `DomainDB.configure()` (DomainDB.swift:39-68), give the four
-      virtual containers `kind = .folder` and leave the rest `nil`.
+- [ ] Add fields to `ItemModel`: `kind` (non-optional), `size`, `permissions`, `accessTime`, `modifyTime`, `createTime` (optionality matching `Item`).
+- [ ] In `DomainDB.configure()` (DomainDB.swift:39-68), give the four virtual containers `kind = .folder` and leave the rest `nil`.
 - [ ] Wire snapshot writes:
-      - `Session.list()` (Session.swift:127) — upsert each child's
-        snapshot after building the `Item`. (Currently this metadata is
-        thrown away.)
-      - `Session.item(for:)` (Session.swift:90) — refresh the snapshot.
-      - The step-1 commit path already populates on insert.
-      - `Session.move()` (Session.swift:238) — no snapshot work; next
-        `list`/poll catches any mtime bump.
+  - [ ] `Session.list()` (Session.swift:127) — upsert each child's snapshot after building the `Item`. (Currently this metadata is thrown away.)
+  - [ ] `Session.item(for:)` (Session.swift:90) — refresh the snapshot.
+  - [ ] The step-1 commit path already populates on insert.
+  - [ ] `Session.move()` (Session.swift:238) — no snapshot work; next `list`/poll catches any mtime bump.
 - [ ] SwiftData lightweight migration with defaults for existing rows.
-- [ ] Tests: snapshot populated after `list`; virtual containers carry
-      their sentinel.
+- [ ] Tests: snapshot populated after `list`; virtual containers carry their sentinel.
 
 **Acceptance:** every non-virtual `ItemModel` carries the same
 `size`/`modifyTime` as the corresponding `Item`.
@@ -133,10 +84,9 @@ populated. Snapshot fields land in step 2.
 - [ ] Add a `ChangeRecord` `@Model` with `anchor: UInt64`, `itemId: String`,
       `kind: ChangeKind` (`.updated` / `.deleted`), indexed on `anchor`.
 - [ ] `DomainDB` helpers:
-      - `bumpAnchor() -> UInt64`
-      - `appendChanges(_ records: [(itemId, kind)])` — batches; bumps the
-        anchor atomically.
-      - `changes(since: UInt64) -> (records: [ChangeRecord], upTo: UInt64)`
+  - [ ] `bumpAnchor() -> UInt64`
+  - [ ] `appendChanges(_ records: [(itemId, kind)])` — batches; bumps the anchor atomically.
+  - [ ] `changes(since: UInt64) -> (records: [ChangeRecord], upTo: UInt64)`
 - [ ] `NSFileProviderSyncAnchor` ↔ `UInt64` encoding helpers.
 - [ ] Replace the hardcoded `"an anchor"` in
       `SSHadow/ExtensionKit/Enumerator.swift` with the real anchor (new
@@ -149,17 +99,11 @@ populated. Snapshot fields land in step 2.
 
 ### Step 4 — `enumerateChanges` reads the journal
 
-- [ ] Add `ChangesRequest(domainId, since: Data) → ChangesResponse(items: [Item], deletedIds: [String], upTo: Data, moreComing: Bool)`
-      to `Common/AgentProtocol.swift`.
-- [ ] Agent side: query `DomainDB.changes(since:)`, hydrate `.updated`
-      via `ItemModel` (snapshot is authoritative after step 2), pass raw
-      ids for `.deleted`.
-- [ ] Wire `Enumerator.enumerateChanges` to feed `observer.didUpdate` /
-      `observer.didDeleteItem`.
-- [ ] Every mutating agent op appends to the journal so we can validate
-      end-to-end before any polling exists.
-- [ ] Integration check in the running app: write a file via Finder,
-      confirm the change reaches the extension and re-renders.
+- [ ] Add `ChangesRequest(domainId, since: Data) → ChangesResponse(items: [Item], deletedIds: [String], upTo: Data, moreComing: Bool)` to `Common/AgentProtocol.swift`.
+- [ ] Agent side: query `DomainDB.changes(since:)`, hydrate `.updated` via `ItemModel` (snapshot is authoritative after step 2), pass raw ids for `.deleted`.
+- [ ] Wire `Enumerator.enumerateChanges` to feed `observer.didUpdate` / `observer.didDeleteItem`.
+- [ ] Every mutating agent op appends to the journal so we can validate end-to-end before any polling exists.
+- [ ] Integration check in the running app: write a file via Finder, confirm the change reaches the extension and re-renders.
 
 **Acceptance:** local mutations produce `enumerateChanges` events without
 needing a directory re-list.
@@ -167,10 +111,8 @@ needing a directory re-list.
 ### Step 5 — Working-set membership tracking
 
 - [ ] Add `workingSet: Bool` to `ItemModel`.
-- [ ] Set the flag when the agent returns an item from `list` or
-      `download`/`stream`. Revisit `fetchContents`-only later.
-- [ ] Add `agent.listWorkingSet(domainId:) -> [Item]` and implement
-      `enumerateItems(.workingSet)` in `Enumerator.swift`.
+- [ ] Set the flag when the agent returns an item from `list` or `download`/`stream`. Revisit `fetchContents`-only later.
+- [ ] Add `agent.listWorkingSet(domainId:) -> [Item]` and implement `enumerateItems(.workingSet)` in `Enumerator.swift`.
 - [ ] Tests for both the flag and the new enumeration path.
 
 **Acceptance:** Finder's working-set view shows the items that have been
@@ -179,37 +121,26 @@ materialized.
 ### Step 6 — Polling loop in `Session`
 
 - [ ] Opt-in polling task that on each interval:
-      1. Collects "interesting" directories: parents of every working-set
-         `ItemModel` plus any directory currently being enumerated (small
-         in-memory set updated from `list`).
+
+      1. Collects "interesting" directories: parents of every working-set `ItemModel` plus any directory currently being enumerated (small in-memory set updated from `list`).
       2. Re-lists each over SFTP.
-      3. Diffs against the snapshot on `ItemModel`: added, missing, or
-         `(size, modifyTime)`-changed children.
-      4. Batches the deltas into `appendChanges` and updates snapshots in
-         the same transaction.
-      5. Pokes the extension via `NSFileProviderManager.signalEnumerator(
-         for: .workingSet)`. Signal path: a one-way XPC message to a
-         long-lived extension callback (fire-and-forget, not a stream).
+      3. Diffs against the snapshot on `ItemModel`: added, missing, or `(size, modifyTime)`-changed children.
+      4. Batches the deltas into `appendChanges` and updates snapshots in the same transaction.
+      5. Pokes the extension via `NSFileProviderManager.signalEnumerator( for: .workingSet)`. Signal path: a one-way XPC message to a long-lived extension callback (fire-and-forget, not a stream).
+
 - [ ] Interval + jitter behind a constant; start at 30s.
-- [ ] "Always poll while the domain is mounted" is fine for v1; revisit
-      pausing on inactivity later.
-- [ ] Integration test against the local sshd: create a file out-of-band,
-      run a poll cycle, assert the journal grew.
-- [ ] **Instrument latency** between `signalEnumerator` and the resulting
-      `enumerateChanges` — log both with timestamps to answer the
-      spin-up question.
+- [ ] "Always poll while the domain is mounted" is fine for v1; revisit pausing on inactivity later.
+- [ ] Integration test against the local sshd: create a file out-of-band, run a poll cycle, assert the journal grew.
+- [ ] **Instrument latency** between `signalEnumerator` and the resulting `enumerateChanges` — log both with timestamps to answer the spin-up question.
 
 **Acceptance:** create a file via plain `ssh` on the test server; within
 one poll interval Finder reflects it.
 
 ### Step 7 — Tighten and observe
 
-- [ ] Confirm per-directory `enumerateChanges` can stay a thin no-op
-      (macOS only polls the working-set enumerator in practice).
-- [ ] Journal pruning: drop records below the minimum anchor seen in the
-      last hour.
-- [ ] Document the anchor + polling story in `CLAUDE.md` under
-      "Key Patterns."
+- [ ] Confirm per-directory `enumerateChanges` can stay a thin no-op (macOS only polls the working-set enumerator in practice).
+- [ ] Journal pruning: drop records below the minimum anchor seen in the last hour.
+- [ ] Document the anchor + polling story in `CLAUDE.md` under "Key Patterns."
 
 ## Open questions (revisit during/after step 6)
 

--- a/ExtensionKit/Enumerator.swift
+++ b/ExtensionKit/Enumerator.swift
@@ -65,12 +65,6 @@ public class Enumerator: NSObject, NSFileProviderEnumerator {
             return nil
         }
 
-        if itemIdentifier == .trashContainer {
-            if try await !agent.exists(for: .trashContainer) {
-                return nil
-            }
-        }
-
         let entries = try await agent.list(for: itemIdentifier)
         for entry in entries {
             let item = FPItem(item: entry)

--- a/ExtensionKit/Extension.swift
+++ b/ExtensionKit/Extension.swift
@@ -363,9 +363,7 @@ public class Extension: NSObject, NSFileProviderReplicatedExtension,
                 try await self.agent.move(
                     item.itemIdentifier,
                     toParent: item.parentId,
-                    name: item.filename,
-                    ifParentNotExists:
-                        item.parentId == .trashContainer ? .create : .fail
+                    name: item.filename
                 )
             }
         }

--- a/ExtensionKitTests/ExtensionTests.swift
+++ b/ExtensionKitTests/ExtensionTests.swift
@@ -21,11 +21,10 @@ struct ExtensionTests {
 
     @Test func readSmallFileSucceeds() async throws {
         // cat extension-read-file/small-file.txt
-        let (ext, agent) = try await getExtensionAndAgent()
-
         let path = "extension-read-file/small-file.txt"
         let contents = "Hello, World!"
         try TestData.createFile(path: path, contents: contents)
+        let (ext, agent) = try await getExtensionAndAgent()
 
         // Fetch FPItemID(<id>)
         let readProgress = Progress()
@@ -46,11 +45,10 @@ struct ExtensionTests {
 
     @Test func readLargeFileSucceeds() async throws {
         // cat extension-read-file/large-file.dat
-        let (ext, agent) = try await getExtensionAndAgent()
-
         let path = "extension-read-file/large-file.dat"
         let data = Data(count: 10_485_760)
         try TestData.createFile(path: path, data: data)
+        let (ext, agent) = try await getExtensionAndAgent()
 
         // Fetch FPItemID(<id>)
         let readProgress = Progress()
@@ -69,13 +67,12 @@ struct ExtensionTests {
 
     @Test func readPartialFileSucceeds() async throws {
         // dd if=extension-read-file/partial-file.dat bs=1m skip=5 count=1
-        let (ext, agent) = try await getExtensionAndAgent()
-
         let path = "extension-read-file/partial-file.dat"
         let data = (0..<1024).reduce(into: Data()) { data, i in
             data.append(contentsOf: repeatElement(UInt8(i % 256), count: 1024))
         }
         try TestData.createFile(path: path, data: data)
+        let (ext, agent) = try await getExtensionAndAgent()
 
         // Read FPItemID(<id>) with range Optional({10240, 10240})
         let requestedRange = NSRange(location: 10 * 1024, length: 10 * 1024)
@@ -107,11 +104,10 @@ struct ExtensionTests {
     }
 
     @Test func readFileWithCancellation() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         let path = "extension-read-file/cancellable-file.txt"
         let data = Data(count: 10_485_760)
         try TestData.createFile(path: path, data: data)
+        let (ext, agent) = try await getExtensionAndAgent()
 
         let progress = Progress()
         let fetchTask = Task {
@@ -130,8 +126,6 @@ struct ExtensionTests {
     }
 
     @Test func createFolderSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // mkdir extension-create-folder/folder
         let oldDate = Date(timeIntervalSince1970: 1_750_000_000)
         let newDate = Date(timeIntervalSince1970: 1_760_000_000)
@@ -141,6 +135,7 @@ struct ExtensionTests {
             path: testPath,
             modifyDate: oldDate
         )
+        let (ext, agent) = try await getExtensionAndAgent()
         let testId = try await agent.child(path: testPath)
 
         let filename = "folder"
@@ -217,8 +212,6 @@ struct ExtensionTests {
     }
 
     @Test func createFileSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // echo "Hello, World!" > extension-create-file/file.txt
         let oldDate = Date(timeIntervalSince1970: 1_750_000_000)
         let newDate = Date(timeIntervalSince1970: 1_760_000_000)
@@ -228,6 +221,7 @@ struct ExtensionTests {
             path: testPath,
             modifyDate: oldDate
         )
+        let (ext, agent) = try await getExtensionAndAgent()
         let testId = try await agent.child(path: testPath)
 
         let filename = "file.txt"
@@ -311,8 +305,6 @@ struct ExtensionTests {
     }
 
     @Test func createLargeFileSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // dd if=/dev/zero of=extension-create-large-file/file.txt bs=1m count=10
         let oldDate = Date(timeIntervalSince1970: 1_750_000_000)
         let newDate = Date(timeIntervalSince1970: 1_760_000_000)
@@ -322,6 +314,7 @@ struct ExtensionTests {
             path: testPath,
             modifyDate: oldDate
         )
+        let (ext, agent) = try await getExtensionAndAgent()
         let testId = try await agent.child(path: testPath)
 
         let filename = "file.txt"
@@ -399,14 +392,11 @@ struct ExtensionTests {
     }
 
     @Test func createSymlinkSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // ln -s target.md extension-symlink-file/symlink.md
         let newDate = Date(timeIntervalSince1970: 1_760_000_000)
 
         let testPath = "extension-symlink-file"
         try TestData.createFolder(path: testPath)
-        let testId = try await agent.child(path: testPath)
         let target = "target.md"
         try TestData.createFile(path: "\(testPath)/\(target)", contents: "data")
 
@@ -414,6 +404,9 @@ struct ExtensionTests {
         let symlinkPath = "\(testPath)/\(filename)"
         try TestData.removeItem(path: symlinkPath)
         let symlinkUrl = TestData.getUrl(path: symlinkPath)
+
+        let (ext, agent) = try await getExtensionAndAgent()
+        let testId = try await agent.child(path: testPath)
 
         // Create FPItem(id: FPItemID(<osid>), parentId: <pid>, filename: symlink.md, contentType: public.symlink, target: target.md, capabilities: FPItemCapabilities(rawValue: 3, reading, writing), fileSystemFlags: FPFileSystemFlags(rawValue: 7, executable, readable, writable), size: 9, createTime: 2026-05-15 00:34:12 +0000, modifyTime: 2026-05-15 00:34:12 +0000, downloaded, mostRecentVersionDownloaded) for FPItemFields(rawValue: 1479, contents, filename, parentItemIdentifier, creationDate, contentModificationDate, fileSystemFlags, typeAndCreator)
         let createSymlinkProgress = Progress()
@@ -460,8 +453,6 @@ struct ExtensionTests {
     }
 
     @Test func renameFileSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // mv extension-rename-file/src.txt extension-rename-file/dest.txt
         let oldDate = Date(timeIntervalSince1970: 1_750_000_000)
         let newDate = Date(timeIntervalSince1970: 1_760_000_000)
@@ -471,7 +462,6 @@ struct ExtensionTests {
             path: folderPath,
             modifyDate: oldDate
         )
-        let folderId = try await agent.child(path: folderPath)
 
         let srcPath = "\(folderPath)/src.txt"
         let srcUrl = try TestData.createFile(
@@ -479,11 +469,14 @@ struct ExtensionTests {
             contents: "data",
             modifyDate: oldDate
         )
-        let srcId = try await agent.child(path: srcPath)
 
         let destFilename = "dest.txt"
         let destPath = "\(folderPath)/\(destFilename)"
         let destUrl = try TestData.removeItem(path: destPath)
+
+        let (ext, agent) = try await getExtensionAndAgent()
+        let folderId = try await agent.child(path: folderPath)
+        let srcId = try await agent.child(path: srcPath)
 
         // Modify FPItem(id: FPItemID(<id>), parentId: FPItemID(<pid>), filename: dest.txt, contentType: public.plain-text, capabilities: FPItemCapabilities(rawValue: 3, reading, writing), fileSystemFlags: FPFileSystemFlags(rawValue: 22, readable, writable, pathExtensionHidden), downloaded, mostRecentVersionDownloaded) for FPItemFields(rawValue: 2, filename)
         let renameProgress = Progress()
@@ -548,8 +541,6 @@ struct ExtensionTests {
     }
 
     @Test func moveFileSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // mv extension-move-file/src/file.txt extension-move-file/dest/
         let oldDate = Date(timeIntervalSince1970: 1_750_000_000)
         let newDate = Date(timeIntervalSince1970: 1_760_000_000)
@@ -559,7 +550,6 @@ struct ExtensionTests {
             path: srcFolderPath,
             modifyDate: oldDate
         )
-        let srcFolderId = try await agent.child(path: srcFolderPath)
 
         let filename = "file.txt"
 
@@ -569,17 +559,20 @@ struct ExtensionTests {
             contents: "data",
             modifyDate: oldDate
         )
-        let srcId = try await agent.child(path: srcPath)
 
         let destFolderPath = "extension-move-file/dest"
         let destFolderUrl = try TestData.createFolder(
             path: destFolderPath,
             modifyDate: oldDate
         )
-        let destFolderId = try await agent.child(path: destFolderPath)
 
         let destPath = "\(destFolderPath)/\(filename)"
         let destUrl = TestData.getUrl(path: destPath)
+
+        let (ext, agent) = try await getExtensionAndAgent()
+        let srcFolderId = try await agent.child(path: srcFolderPath)
+        let srcId = try await agent.child(path: srcPath)
+        let destFolderId = try await agent.child(path: destFolderPath)
 
         // Modify FPItem(id: FPItemID(<pid>), parentId: FPItemID(<npid>), filename: file.txt, contentType: public.plain-text, capabilities: FPItemCapabilities(rawValue: 3, reading, writing), fileSystemFlags: FPFileSystemFlags(rawValue: 22, readable, writable, pathExtensionHidden), downloaded, mostRecentVersionDownloaded) for FPItemFields(rawValue: 4, parentItemIdentifier)
         let moveProgress = Progress()
@@ -676,23 +669,23 @@ struct ExtensionTests {
     }
 
     @Test func moveAndRenameFileSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // mv extension-move-rename/src/old.txt extension-move-rename/dest/new.txt
         let srcFolderPath = "extension-move-rename/src"
         try TestData.createFolder(path: srcFolderPath)
 
         let srcPath = "\(srcFolderPath)/old.txt"
         try TestData.createFile(path: srcPath, contents: "data")
-        let srcId = try await agent.child(path: srcPath)
 
         let destFolderPath = "extension-move-rename/dest"
         try TestData.createFolder(path: destFolderPath)
-        let destFolderId = try await agent.child(path: destFolderPath)
 
         let newName = "new.txt"
         let destUrl = TestData.getUrl(path: "\(destFolderPath)/\(newName)")
         try TestData.removeItem(path: "\(destFolderPath)/\(newName)")
+
+        let (ext, agent) = try await getExtensionAndAgent()
+        let srcId = try await agent.child(path: srcPath)
+        let destFolderId = try await agent.child(path: destFolderPath)
 
         let progress = Progress()
         let (maybeItem, pendingFields, shouldFetch) = try await ext.modifyItem(
@@ -731,19 +724,19 @@ struct ExtensionTests {
     }
 
     @Test func moveFilePreservesIdentifier() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // mv extension-move-preserve-id/file.txt extension-move-preserve-id/dest/
         let filename = "file.txt"
         let srcPath = "extension-move-preserve-id/\(filename)"
         try TestData.createFile(path: srcPath, contents: "data")
-        let srcId = try await agent.child(path: srcPath)
 
         let destFolderPath = "extension-move-preserve-id/dest"
         try TestData.createFolder(path: destFolderPath)
-        let destFolderId = try await agent.child(path: destFolderPath)
 
         try TestData.removeItem(path: "\(destFolderPath)/\(filename)")
+
+        let (ext, agent) = try await getExtensionAndAgent()
+        let srcId = try await agent.child(path: srcPath)
+        let destFolderId = try await agent.child(path: destFolderPath)
 
         let (maybeItem, pendingFields, shouldFetch) = try await ext.modifyItem(
             ItemTemplate(
@@ -776,8 +769,6 @@ struct ExtensionTests {
     }
 
     @Test func trashFileSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // mv extension-trash-file/file.txt .sshadow/trash/file.txt
         let filename = "file.txt"
         let filePath = "extension-trash-file/\(filename)"
@@ -785,10 +776,12 @@ struct ExtensionTests {
             path: filePath,
             contents: "data"
         )
-        let fileId = try await agent.child(path: filePath)
 
         try TestData.removeItem(path: ".sshadow")
         let trashedUrl = TestData.getUrl(path: ".sshadow/trash/\(filename)")
+
+        let (ext, agent) = try await getExtensionAndAgent()
+        let fileId = try await agent.child(path: filePath)
 
         // Modify FPItem(id: FPItemID(<id>), parentId: FPItemID.trashContainer, filename: file.txt, contentType: public.plain-text, capabilities: FPItemCapabilities(rawValue: 3, reading, writing), fileSystemFlags: FPFileSystemFlags(rawValue: 22, readable, writable, pathExtensionHidden), downloaded, mostRecentVersionDownloaded) for FPItemFields(rawValue: 4, parentItemIdentifier)
         let trashProgress = Progress()
@@ -826,8 +819,6 @@ struct ExtensionTests {
     }
 
     @Test func editFileSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // echo "World!" >> extension-edit-file/file.txt
         let oldDate = Date(timeIntervalSince1970: 1_750_000_000)
         let newDate = Date(timeIntervalSince1970: 1_760_000_000)
@@ -837,7 +828,6 @@ struct ExtensionTests {
             path: folderPath,
             modifyDate: oldDate
         )
-        let folderId = try await agent.child(path: folderPath)
 
         let oldContent = "Hello, "
         let filePath = "\(folderPath)/file.txt"
@@ -846,6 +836,9 @@ struct ExtensionTests {
             contents: oldContent,
             modifyDate: oldDate
         )
+
+        let (ext, agent) = try await getExtensionAndAgent()
+        let folderId = try await agent.child(path: folderPath)
         let fileId = try await agent.child(path: filePath)
 
         // Fetch FPItemID(<id>)
@@ -915,8 +908,6 @@ struct ExtensionTests {
     }
 
     @Test func setFileReadWriteSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // chmod 600 extension-permissions/file.txt
         let testPath = "extension-permissions"
 
@@ -926,6 +917,8 @@ struct ExtensionTests {
             contents: "data",
             permissions: 0o000
         )
+
+        let (ext, agent) = try await getExtensionAndAgent()
         let fileId = try await agent.child(path: filePath)
 
         // Modify FPItem(id: FPItemID(<id>), parentId: FPItemID(<pid>), filename: file.txt, contentType: public.plain-text, capabilities: FPItemCapabilities(rawValue: 3, reading, writing), fileSystemFlags: FPFileSystemFlags(rawValue: 22, readable, writable, pathExtensionHidden), downloaded, mostRecentVersionDownloaded) for FPItemFields(rawValue: 256, fileSystemFlags)
@@ -956,8 +949,6 @@ struct ExtensionTests {
     }
 
     @Test func setFolderReadWriteExecuteSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // chmod 700 extension-permissions/folder
         let testPath = "extension-permissions"
 
@@ -966,6 +957,8 @@ struct ExtensionTests {
             path: folderPath,
             permissions: 0o000
         )
+
+        let (ext, agent) = try await getExtensionAndAgent()
         let folderId = try await agent.child(path: folderPath)
 
         // Modify FPItem(id: FPItemID(<id>), parentId: FPItemID(<pid>), filename: folder, contentType: public.folder, capabilities: FPItemCapabilities(rawValue: 3, reading, writing), fileSystemFlags: FPFileSystemFlags(rawValue: 7, executable, readable, writable), downloaded, mostRecentVersionDownloaded) for FPItemFields(rawValue: 256, fileSystemFlags)
@@ -1000,13 +993,13 @@ struct ExtensionTests {
     }
 
     @Test func deleteFolderSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // rmdir extension-delete-item/folder
         let testPath = "extension-delete-item"
 
         let folderPath = "\(testPath)/folder"
         let folderUrl = try TestData.createFolder(path: folderPath)
+
+        let (ext, agent) = try await getExtensionAndAgent()
         let folderId = try await agent.child(path: folderPath)
 
         // Delete FPItemID(<id>)
@@ -1023,8 +1016,6 @@ struct ExtensionTests {
     }
 
     @Test func deleteFileSucceeds() async throws {
-        let (ext, agent) = try await getExtensionAndAgent()
-
         // rm extension-delete-item/file.txt
         let testPath = "extension-delete-item"
 
@@ -1034,6 +1025,8 @@ struct ExtensionTests {
             path: filePath,
             contents: contents
         )
+
+        let (ext, agent) = try await getExtensionAndAgent()
         let fileId = try await agent.child(path: filePath)
 
         // Delete FPItemID(<id>)


### PR DESCRIPTION
- Drop `exists` method which was only used for trash folder detection
- Drop `ifNotExists` from `child` method because all `child` calls now fail if the path doesn't exist
- Drop `ifParentNotExists` from `move` method because this was only used to create the trash folder